### PR TITLE
Criacao regra cinco enderecos

### DIFF
--- a/src/main/java/com/github/clientes/controllers/AddressController.java
+++ b/src/main/java/com/github/clientes/controllers/AddressController.java
@@ -3,15 +3,11 @@ package com.github.clientes.controllers;
 import java.util.List;
 import java.util.UUID;
 
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.github.clientes.dto.CreateAddressDTO;
 import com.github.clientes.entities.AddressEntity;
@@ -25,6 +21,8 @@ public class AddressController {
 
     @Autowired
     private AddressService addressService;
+
+
 
     @GetMapping
     public ResponseEntity<List<AddressEntity>> findAllAddresses() {
@@ -50,6 +48,36 @@ public class AddressController {
             return ResponseEntity.status(HttpStatus.CREATED).body(addressService.createAddress(createAddressDTO));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+
+
+        }
+
+    }
+
+    @PatchMapping("/{externalUuid}")
+    public ResponseEntity <AddressEntity> updateAddress (@PathVariable String externalUuid, @Valid @RequestBody CreateAddressDTO createAddressDTO) {
+        AddressEntity updatedAddress = addressService.updateAddress(externalUuid, createAddressDTO);
+
+        if (updatedAddress == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+
+        return ResponseEntity.status(HttpStatus.OK).body(updatedAddress);
+
+    }
+
+    @DeleteMapping("/{externalUuid}")
+    public ResponseEntity<String> deleteAddress(@PathVariable String externalUuid) {
+        try {
+            boolean deleted = addressService.deleteAddress(externalUuid);
+
+            if (deleted) {
+                return ResponseEntity.status(HttpStatus.OK).body("Endereço excluído com sucesso");
+            } else {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Endereço não encontrado");
+            }
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Erro ao excluir o Endereço: ");
         }
     }
 

--- a/src/main/java/com/github/clientes/dto/CreateAddressDTO.java
+++ b/src/main/java/com/github/clientes/dto/CreateAddressDTO.java
@@ -19,7 +19,10 @@ public record CreateAddressDTO(
 
         @NotNull(message = "A informação estado da federação não pode ser nula")
         @NotBlank(message = "A informação estado da federação não pode estar vazia")
-        String uf
+        String uf,
+
+         @NotNull(message = "O ID do cliente não pode ser nulo")
+         Long customerId
 
 
 ) {

--- a/src/main/java/com/github/clientes/enterprise/AddressLimitExceededException.java
+++ b/src/main/java/com/github/clientes/enterprise/AddressLimitExceededException.java
@@ -1,0 +1,7 @@
+package com.github.clientes.enterprise;
+
+public class AddressLimitExceededException extends RuntimeException{
+    public AddressLimitExceededException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/github/clientes/entities/AddressEntity.java
+++ b/src/main/java/com/github/clientes/entities/AddressEntity.java
@@ -1,51 +1,51 @@
-package com.github.clientes.entities;
+    package com.github.clientes.entities;
 
-import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import org.hibernate.annotations.CurrentTimestamp;
+    import jakarta.persistence.*;
+    import lombok.AllArgsConstructor;
+    import lombok.Getter;
+    import lombok.NoArgsConstructor;
+    import lombok.Setter;
+    import org.hibernate.annotations.CurrentTimestamp;
 
-import java.time.LocalDateTime;
-import java.util.UUID;
-
-
-@Entity
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-@Table(name = "tb_address")
-public class AddressEntity extends EntityId{
+    import java.time.LocalDateTime;
+    import java.util.UUID;
 
 
-    @Column(name = "externalUUID", nullable = false)
-    private UUID externalUuid;
-    @Column (name = "rua", nullable = false)
-    private String rua;
-
-    @Column(name = "bairro", nullable = false)
-    private String bairro;
-
-    @Column(name = "cidade", nullable = false)
-    private String cidade;
-
-    @Column(name = "uf", nullable = false)
-    private String uf;
-
-    @CurrentTimestamp
-    @Column(name = "data_cadastro", nullable = false)
-    private LocalDateTime dataCadastro;
-
-    @ManyToOne
-    @JoinColumn(name = "customer_id", nullable = false)
-    private CustomerEntity customer;
+    @Entity
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Table(name = "tb_address")
+    public class AddressEntity extends EntityId{
 
 
-    @PrePersist
-    private void generateExternalUuid() {
-        this.externalUuid = UUID.randomUUID();
+        @Column(name = "externalUUID", nullable = false)
+        private UUID externalUuid;
+        @Column (name = "rua", nullable = false)
+        private String rua;
+
+        @Column(name = "bairro", nullable = false)
+        private String bairro;
+
+        @Column(name = "cidade", nullable = false)
+        private String cidade;
+
+        @Column(name = "uf", nullable = false)
+        private String uf;
+
+        @CurrentTimestamp
+        @Column(name = "data_cadastro", nullable = false)
+        private LocalDateTime dataCadastro;
+
+        @ManyToOne
+        @JoinColumn(name = "customer_id", nullable = false)
+        private CustomerEntity customer;
+
+
+        @PrePersist
+        private void generateExternalUuid() {
+            this.externalUuid = UUID.randomUUID();
+        }
+
     }
-
-}

--- a/src/main/java/com/github/clientes/entities/EntityId.java
+++ b/src/main/java/com/github/clientes/entities/EntityId.java
@@ -5,7 +5,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 
+@Getter
 @MappedSuperclass
 public class EntityId {
     @Id

--- a/src/main/java/com/github/clientes/repositories/AddressRepository.java
+++ b/src/main/java/com/github/clientes/repositories/AddressRepository.java
@@ -2,8 +2,12 @@ package com.github.clientes.repositories;
 
 import com.github.clientes.entities.AddressEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
@@ -11,4 +15,18 @@ public interface AddressRepository extends JpaRepository <AddressEntity, Long> {
 
     AddressEntity findByExternalUuid(UUID externalUuid);
 
+    @Query("SELECT c.id AS clienteId, COUNT(DISTINCT CONCAT(a.rua, a.bairro, a.cidade, a.uf)) AS totalCadastros " +
+            "FROM AddressEntity a " +
+            "INNER JOIN CustomerEntity c ON a.customer.id = c.id " +
+            "GROUP BY c.id " +
+            "ORDER BY totalCadastros DESC")
+    List<Object[]> countDistinctAddressesByCustomerId();
+
+    @Modifying
+    @Transactional
+    void deleteByExternalUuid(UUID externalUuid);
 }
+
+
+
+

--- a/src/main/java/com/github/clientes/services/AddressService.java
+++ b/src/main/java/com/github/clientes/services/AddressService.java
@@ -113,6 +113,11 @@ private ModelMapper modelMapper;
         return addressRepository.save(address);
     }
 
+    public AddressEntity findCustomerByExternalUuid(String externalUuid) {
+        UUID uuid = UUID.fromString(externalUuid);
+        return addressRepository.findByExternalUuid(uuid);
+    }
+
 }
 
 

--- a/src/main/java/com/github/clientes/services/AddressService.java
+++ b/src/main/java/com/github/clientes/services/AddressService.java
@@ -4,18 +4,25 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 
+import com.github.clientes.enterprise.AddressLimitExceededException;
+import com.github.clientes.entities.CustomerEntity;
+import com.github.clientes.repositories.CustomerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.github.clientes.dto.CreateAddressDTO;
 import com.github.clientes.entities.AddressEntity;
 import com.github.clientes.repositories.AddressRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class AddressService {
 
 @Autowired
 AddressRepository addressRepository;
+
+@Autowired
+CustomerRepository customerRepository;
 
 
     public List<AddressEntity> findAllAddress() {
@@ -43,15 +50,53 @@ AddressRepository addressRepository;
     }
 
 
+    @Transactional
     public AddressEntity createAddress(CreateAddressDTO addressDTO) {
+
+        CustomerEntity customer = customerRepository.findById(addressDTO.customerId())
+                .orElseThrow(() -> new NoSuchElementException("Cliente não encontrado"));
+
+        List<Object[]> addressStats = addressRepository.countDistinctAddressesByCustomerId();
+
+        long totalDistinctAddresses = addressStats.stream()
+                .filter(record -> ((Long) record[0]).equals(customer.getId()))
+                .mapToLong(record -> (Long) record[1])
+                .findFirst()
+                .orElse(0);
+
+        if (totalDistinctAddresses >= 5) {
+            throw new AddressLimitExceededException("Limite de 5 endereços distintos excedido.");
+        }
+
         AddressEntity newAddress = new AddressEntity();
         newAddress.setRua(addressDTO.rua());
         newAddress.setBairro(addressDTO.bairro());
         newAddress.setCidade(addressDTO.cidade());
         newAddress.setUf(addressDTO.uf());
 
+        newAddress.setCustomer(customer);
+
         return addressRepository.save(newAddress);
     }
 
 
+    @jakarta.transaction.Transactional
+    public boolean deleteAddress(String externalUuid) {
+        try {
+            UUID uuid = UUID.fromString(externalUuid);
+            AddressEntity address = addressRepository.findByExternalUuid(uuid);
+
+            if (address == null) {
+                return false;
+            }
+
+            addressRepository.deleteByExternalUuid(uuid);
+            return true;
+        } catch (Exception e) {
+            throw new RuntimeException("Erro ao tentar excluir o registro de endereço");
+        }
+    }
+
 }
+
+

--- a/src/main/java/com/github/clientes/services/AddressService.java
+++ b/src/main/java/com/github/clientes/services/AddressService.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import com.github.clientes.enterprise.AddressLimitExceededException;
 import com.github.clientes.entities.CustomerEntity;
 import com.github.clientes.repositories.CustomerRepository;
+import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -23,6 +24,9 @@ AddressRepository addressRepository;
 
 @Autowired
 CustomerRepository customerRepository;
+
+@Autowired
+private ModelMapper modelMapper;
 
 
     public List<AddressEntity> findAllAddress() {
@@ -95,6 +99,18 @@ CustomerRepository customerRepository;
         } catch (Exception e) {
             throw new RuntimeException("Erro ao tentar excluir o registro de endereço");
         }
+    }
+
+    public AddressEntity updateAddress(String externalUuid, CreateAddressDTO createAddressDTO) {
+        AddressEntity address = addressRepository.findByExternalUuid(UUID.fromString(externalUuid));
+
+        if (address == null) {
+            throw new RuntimeException("Endereço não encontrado");
+        }
+
+        modelMapper.map(createAddressDTO, address);
+
+        return addressRepository.save(address);
     }
 
 }


### PR DESCRIPTION
### Tipo de Mudança
- **feat**: Implementação regras de negócio para que seja permitido apenas 5 endereços por cliente.
- **feat**: Exception personalizada para o registro de endereços.
- **feat**: Update e delete na service.
- **feat**: Getter no EntityId
- **feat**: Adição do método findCustomerByExternalUuid
- **feat**: Finalização AddressController

### Descrição
Este PR abrange:

1. **Implementação regras de negócio para que seja permitido apenas 5 endereços por cliente**: É permitido a criação de apenas 5 endereços por cliente. Caso seja tentado cadastrar além de 5, dará uma exception.
   
2. **Exception personalizada para o registro de endereços.**: Criação de  uma Exception personalizada para o registro de endereços.

3. **Update e delete na service e controller**: Implementação do patch e do delete no service e no controller.

4. **Adição do método findCustomerByExternalUuid**: Adição do método findCustomerByExternalUuid na service da classe Address.

